### PR TITLE
Adding link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ bioportal_client = BioPortalClient()
 ontologies = bioportal_client.get_ontologies()
 ```
 
+Complete documentation can be found on [ontoportal-client.readthedocs.io](https://ontoportal-client.readthedocs.io/)
+
 ## 🚀 Installation
 
 ```shell


### PR DESCRIPTION
The location of the docs is not obvious to people not well versed in badgery hermeneutics

You may also want to configure the link in the top right too